### PR TITLE
On MacOS X default the device to /dev/tty.usbserial

### DIFF
--- a/sconsole.c
+++ b/sconsole.c
@@ -228,7 +228,11 @@ int main(int argc, char *argv[])
 {
 	struct pollfd fds[2];
 	int speed = B115200;
+#ifdef __APPLE__
+	const char *device = "/dev/tty.usbserial";
+#else
 	const char *device = "/dev/ttyUSB0";
+#endif
 	const char *logfile = "console.log";
 	int fd, n;
 	int map_nl_to_cr = 0;


### PR DESCRIPTION
The default is right on linux but not on OSX. This adds it.
